### PR TITLE
added shoulda-matchers gem for testing with RSpec, created the compan…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
+  # Enable methods for model's testing with RSpec
+  gem 'shoulda-matchers', '~> 5.0'
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
@@ -217,6 +219,8 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
+    shoulda-matchers (5.1.0)
+      activesupport (>= 5.2.0)
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -263,6 +267,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   autoprefixer-rails (= 10.2.5)
@@ -284,6 +289,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (>= 6)
   selenium-webdriver
+  shoulda-matchers (~> 5.0)
   simple_form
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Company, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  it 'checks if the initialize method accepts :name on creation' do
+    test_company = Company.new(name: 'Test Company')
+    expect(test_company.name).to eq('Test Company')
+  end
+
+  it 'checks if a company\'s name can be changed' do
+    test_company = Company.new(name: 'Test Company')
+    test_company.name = 'New Test Company'
+    expect(test_company.name).to eq('New Test Company')
+  end
+
+  context 'presence of name validation'do
+    it { should validate_presence_of(:name) }
+  end
+  context 'checks if it has many teams' do
+    it { should have_many(:teams) }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,3 +62,11 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+# Adding configuration for shoulda-matchers gem:
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
# Description
Added shoulda-matchers gem for testing with RSpec.
It's probably the most famous gem for checking validations/associations of models, for more information about the matchers and usage please refer to:
https://matchers.shoulda.io/
https://github.com/thoughtbot/shoulda-matchers#rspec

# Type of change

Please mark 'X' as appropriate:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix/feature update (non-breaking change which fixes an issue/changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Added a new gem so after pulling:
**bundle install**

When you want to run the tests **avoid using**:
**rspec spec** 
as it doesn't work with the test DB, to be able to use the current information available in the test DB you must use 
**rake** (or **rake spec**, both work)

By default the created files have pending tests. Added 4 test to the company model that check:
initialize method (if it accepts :name on creation)
@company.name = 'new name' (if it's possible to change a company's name, in few words if attr_accessor is working)
validations & associations: presence of :name and if has_many teams
 